### PR TITLE
 Rails 5.2 support for safe_connection function

### DIFF
--- a/lib/octopus/proxy.rb
+++ b/lib/octopus/proxy.rb
@@ -76,7 +76,11 @@ module Octopus
       connection_pool.connection
     rescue NoMethodError
       proxy_config.reinitialize_shards
-      retry
+      connection_pool.automatic_reconnect ||= true
+      if !connection_pool.connected? && shards[Octopus.master_shard].connection.query_cache_enabled
+        connection_pool.connection.enable_query_cache!
+      end
+      connection_pool.connection
     end
 
     def select_connection


### PR DESCRIPTION
## Summary

Required changes for Rails 5.2 support, this is due some issue with HoneyBadger https://app.honeybadger.io/projects/54131/faults/101352659/01HCNXCCD9PH2SYJ5N25021DDP?page=0

At some point some connections are discarded that's why we need to add a rescue and reinitialize the shards

## 🔀 Changes
- Add rescue in Proxy to safe_connections function

